### PR TITLE
pixiv-winter-internship 2015課題

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -16,7 +16,7 @@ call_user_func(function(){
     $routing_map = [
         'logout'   => ['GET',  '/logout',      'logout'],
         'login'    => ['GET',  '/login',       'login'],
-                      ['GET',  '/login',       'login'],
+                      ['POST',  '/login',       'login'],
         'regist'   => ['GET',  '/regist',      'regist'],
                       ['POST', '/regist',      'regist'],
         'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],

--- a/setup
+++ b/setup
@@ -39,6 +39,11 @@ fwrite(STDERR, "[DSN] {$sqlite_dsn}\n");
 
 $pdo = new \PDO($sqlite_dsn, null, null, [PDO::ATTR_PERSISTENT => true]);
 
+
+$system_pass = password_hash("system",PASSWORD_DEFAULT);
+$root_pass = password_hash("nimda",PASSWORD_DEFAULT);
+$chobi_pass = password_hash("cbcb",PASSWORD_DEFAULT);
+
 $queries = [
     'CREATE TABLE `users`( `id` INTEGER PRIMARY KEY AUTOINCREMENT, `slug` TEXT UNIQUE, `name` TEXT )',
     'CREATE TABLE `user_passwords`( `user_id` INTEGER PRIMARY KEY, `password` TEXT )',
@@ -57,12 +62,12 @@ $queries = [
     'CREATE INDEX `in_room_user_id` ON `in_rooms`( `user_id` )',
 
     'INSERT INTO `users` VALUES( 0, "system", "System" )',
-    'INSERT INTO `user_passwords` VALUES( 0, "system" )',
+    'INSERT INTO `user_passwords` VALUES( 0, "' . $system_pass. '" )',
     'INSERT INTO `users` VALUES( 1, "root", "super user" )',
-    'INSERT INTO `user_passwords` VALUES( 1, "nimda" )',
+    'INSERT INTO `user_passwords` VALUES( 1, "' . $root_pass .'" )',
     'INSERT INTO `user_profile` VALUES( 1, "http://pixiv.co.jp/", "pixiv", "AB" )',
     'INSERT INTO `users` VALUES( 2, "chobi", "チョビ" )',
-    'INSERT INTO `user_passwords` VALUES( 2, "cbcb" )',
+    'INSERT INTO `user_passwords` VALUES( 2, "' . $chobi_pass . '" )',
     'INSERT INTO `user_profile` VALUES( 2, "http://times.pixiv.net/post/38140118669/%E3%83%94%E3%82%AF%E3%82%B7%E3%83%96%E3%81%AE%E7%A4%BE%E5%93%A1%E7%8A%AC", "chobi_pixiv", "Bombay" )',
     'INSERT INTO `rooms` VALUES( 1, "operators", "運営委員会" )',
     'INSERT INTO `rooms` VALUES( 2, "idobata-talks", "雑談の部屋" )',

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -10,22 +10,22 @@ class regist
         if ($app->session->get('user_id', ['default' => false])) {
             return new Response\RedirectResponse('/');
         }
-
-        $is_daburi = self::isTyouhuku(isset($_REQUEST['user']) ?? '');
-
-        if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['password'])) {
+        if(isset($_REQUEST['slug'],$_REQUEST['user'],$_REQUEST['password'])){
+            $is_daburi = self::isTyouhuku($_REQUEST['slug']);
+        }
+        if (isset($is_daburi) && $is_daburi){
+            return new Response\TwigResponse('regist.tpl.html', [
+                'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
+                'is_daburi' => $is_daburi,
+            ]);
+        }
+        else{
             $login = self::regist($_REQUEST['slug'], $_REQUEST['user'], $_REQUEST['password']);
             $app->session->set('user_id', $login['id']);
             $app->session->set('user_slug', $login['slug']);
             $app->session->set('user_name', $login['name']);
-
             return new Response\RedirectResponse('/');
         }
-
-        return new Response\TwigResponse('regist.tpl.html', [
-            'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
-            'is_daburi' => $is_daburi,
-        ]);
     }
 
     private static function isTyouhuku(string $user_name): bool

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -36,7 +36,6 @@ class regist
         }
 
         $user = trim($user_name);
-        $pass = $_REQUEST['password'];
         $query = "SELECT * FROM `users` WHERE `slug` = \"${user}\" ";
         $stmt = db()->prepare($query);
         $stmt->execute();
@@ -45,13 +44,14 @@ class regist
         return !empty($data);
     }
 
-    private static function regist($slug, $name, $password): array
+    private static function regist($slug, $name, $plain_password): array
     {
         $query = "INSERT INTO `users`(`slug`, `name`) VALUES( \"{$slug}\", \"{$name}\" ); ";
         $stmt = db()->prepare($query);
         $stmt->execute();
-
+        
         $id = db()->lastInsertId();
+        $password = password_hash($plain_password, PASSWORD_DEFAULT);
         $query = "INSERT INTO `user_passwords` VALUES( {$id}, \"{$password}\" ); ";
         $stmt = db()->prepare($query);
         $stmt->execute();

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -2,22 +2,22 @@
 {% block title %}Top{% endblock %}
 {% block content %}
     {% if isLoggedIn %}
-        <form action="/add_room" method=post class="loginform">
+        <form action="/add_room" method="post" class="loginform">
             <fieldset>
                 <legend>部屋追加</legend>
-                <input name=name required placeholder="部屋名" >
-                URL: <code>http://{{ server.HTTP_HOST }}/rooms/<input name=slug required placeholder="slug" pattern="[a-zA-Z0-9]+"></code>
-                <input name=user_id value="{{ loginUser.id }}" type=hidden>
-                <button type=submit>追加</button>
+                <input name="name" required placeholder="部屋名" >
+                URL: <code>http://{{ server.HTTP_HOST }}/rooms/<input name="slug" required placeholder="slug" pattern="[a-zA-Z0-9]+"></code>
+                <input name="user_id" value="{{ loginUser.id }}" type="hidden">
+                <button type="submit">追加</button>
             </fieldset>
         </form>
     {% else %}
         <form action="/login" class="loginform">
             <fieldset>
                 <legend>Login</legend>
-                <input name=user value="{{ user }}" >
-                <input name=password>
-                <button type=submit>Login</button>
+                <input name="user" value="{{ user }}" type="text">
+                <input name="password" type="password">
+                <button type="submit">Login</button>
             </fieldset>
         </form>
     {% endif %}

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -12,7 +12,7 @@
             </fieldset>
         </form>
     {% else %}
-        <form action="/login" class="loginform">
+        <form action="/login" class="loginform" method="post">
             <fieldset>
                 <legend>Login</legend>
                 <input name="user" value="{{ user }}" type="text" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -20,6 +20,9 @@
                 <button type="submit">Login</button>
             </fieldset>
         </form>
+	<button type="button" onclick="location.href='/regist'">新規登録</button> 
+	
+
     {% endif %}
     <h2>部屋一覧</h2>
     <ul>

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -15,8 +15,8 @@
         <form action="/login" class="loginform">
             <fieldset>
                 <legend>Login</legend>
-                <input name="user" value="{{ user }}" type="text">
-                <input name="password" type="password">
+                <input name="user" value="{{ user }}" type="text" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
+		<input name="password" placeholder="パスワード" type="password">
                 <button type="submit">Login</button>
             </fieldset>
         </form>

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-    <form action="/login" class="loginform">
+    <form action="/login" class="loginform" method="post">
         <fieldset>
             <legend>Login</legend>
             <input name="user" value="{{ user }}" type="text" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -4,9 +4,9 @@
     <form action="/login" class="loginform">
         <fieldset>
             <legend>Login</legend>
-            <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
-            <input name=password placeholder="パスワード">
-            <button type=submit>Login</button>
+            <input name="user" value="{{ user }}" type="text" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
+            <input name="password" placeholder="パスワード" type="password">
+            <button type="submit">Login</button>
         </fieldset>
     </form>
 {% endblock %}

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -6,7 +6,7 @@
             <legend>Regist</legend>
             <input name="user" value="{{ user }}" required placeholder="ユーザー名" >
             <input name="slug" value="{{ slug }}" required placeholder="ログイン名"  pattern="[a-zA-Z0-9]+">
-            <input name="password" required placeholder="パスワード" type="password">
+            <input name="password" required placeholder="パスワード" type="password" value="{{password_hash(value, PASSWORD_DEFAULT)}}">
             <button type="submit">Submit</button>
         </fieldset>
     </form>

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -4,10 +4,10 @@
     <form action="/regist" class="loginform">
         <fieldset>
             <legend>Regist</legend>
-            <input name=user value="{{ user }}" required placeholder="ユーザー名" >
-            <input name=slug value="{{ slug }}" required placeholder="ログイン名"  pattern="[a-zA-Z0-9]+">
-            <input name=password required placeholder="パスワード">
-            <button type=submit>Submit</button>
+            <input name="user" value="{{ user }}" required placeholder="ユーザー名" >
+            <input name="slug" value="{{ slug }}" required placeholder="ログイン名"  pattern="[a-zA-Z0-9]+">
+            <input name="password" required placeholder="パスワード" type="password">
+            <button type="submit">Submit</button>
         </fieldset>
     </form>
 {% endblock %}

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -6,7 +6,7 @@
             <legend>Regist</legend>
             <input name="user" value="{{ user }}" required placeholder="ユーザー名" >
             <input name="slug" value="{{ slug }}" required placeholder="ログイン名"  pattern="[a-zA-Z0-9]+">
-            <input name="password" required placeholder="パスワード" type="password" value="{{password_hash(value, PASSWORD_DEFAULT)}}">
+            <input name="password" required placeholder="パスワード" type="password">
             <button type="submit">Submit</button>
         </fieldset>
     </form>

--- a/src/View/twig/room.tpl.html
+++ b/src/View/twig/room.tpl.html
@@ -2,11 +2,11 @@
 {% block title %}[{{ room.slug }}] {{ room.name }} | Wintern Chat{% endblock %}
 {% block content %}
     {% if isLoggedIn %}
-        <form action="/rooms/{{ slug }}" class=comment method=post>
-            <input name=message>
-            <input name=user_id type=hidden value={{ loginUser.id }}>
-            <input name=slug type=hidden value={{ slug }}>
-            <button name=submit>更新</button>
+        <form action="/rooms/{{ slug }}" class="comment" method="post">
+            <input name="message">
+            <input name="user_id" type="hidden" value="{{ loginUser.id }}">
+            <input name="slug" type="hidden" value="{{ slug }}">
+            <button name="submit">更新</button>
         </form>
     {% else %}
         <a href="/login">ログイン</a>


### PR DESCRIPTION
# Wintern Chat

修正内容は以下のとおり
#### 備考
- DB : データベース
- プレースホルダー : 入力ボックスに未入力状態で表示される文字列
- XSS, SQLi, CSRF: 脆弱性名称([参考](https://www.ipa.go.jp/files/000017316.pdf))
## inputフォームの修正 [#d591161, #0e6e36f]
### why
- 入力内容が画面から丸見え．[ショルダーハック](https://www.google.co.jp/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0CB4QFjAAahUKEwjm59Spx5TJAhWGMaYKHQPYAho&url=http%3A%2F%2Fe-words.jp%2Fw%2F%25E3%2582%25B7%25E3%2583%25A7%25E3%2583%25AB%25E3%2583%2580%25E3%2583%25BC%25E3%2583%258F%25E3%2583%2583%25E3%2582%25AF.html&usg=AFQjCNGmKAuS-4fc8ZvRw7fuBztl_tv6hw&sig2=jCQkz2Zy1720jGx8Q9tirA&bvm=bv.107467506,d.dGY)し放題.  
- inputタグの書き方が統一されておらず，ページによって書き方がバラバラ
### solution
- inputタグのtypeをpasswordにした
- inputタグの書き方(属性をダブルクォートで囲う，プレースホルダー等)を統一
## formの通信をPOSTへ変更 [#35dee15]
### why
- GETだとURLから見える（POSTでも通信経路上では見えてしまうがURLよりはマシ）
- GETでは送信できるデータに制限がかかる
- 安直なCSRFの阻止
### solution
- inputのmethodをPOSTに
- htdocs/index.phpのルーティングにあったGETのダブりをPOSTへ変更
## registページへのリンク追加 [#eb2b64f]
### why
- topページへ来た新規ユーザーがユーザーの登録ができない(つまり新規お断り状態)
### solution
- topページへregistページへのリンクを貼る
## DBに保存するパスワードのハッシュ化 [#f2b03e3]
### why
- DBに平文で保存されていたため，DBへアクセス可能な人間は全てパスワードが覗き見れる
### solution
- password_hash関数を利用してDBへ保存する文字列を全てハッシュ化
- 認証時には送信されたパスワードとDBのハッシュをpassword_verify関数を利用してチェック
## registから不正にloginできるバグを修正 [#58cbfe1]
### why
- slugを知られるだけで他人に勝手にログインされる
- システム管理ユーザーが存在するため，管理ユーザーのslugを知られると致命的
### solution
- regist.phpのisTouhukuメソッドが正常に働くよう修正

---
# TODO

キリがなかったので今回以下は保留
- XSS診断と対策
  - 手で試した分には問題なさそう
- SQLi診断と対策
  - デフォルトでは`" OR 1=1 LIMIT 1,1/*`が通った気がする(修正後未確認)
- CSRF診断と対策
  - Symphonyならオプションを加えるだけで対策が可能なはず
