### PR TITLE
pixiv-winter-internship 2015課題

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -16,7 +16,7 @@ call_user_func(function(){
     $routing_map = [
         'logout'   => ['GET',  '/logout',      'logout'],
         'login'    => ['GET',  '/login',       'login'],
-                      ['GET',  '/login',       'login'],
+                      ['POST',  '/login',       'login'],
         'regist'   => ['GET',  '/regist',      'regist'],
                       ['POST', '/regist',      'regist'],
         'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],

--- a/htdocs/wintern.css
+++ b/htdocs/wintern.css
@@ -14,8 +14,12 @@ a {
     text-decoration: none;
 }
 
+a:link {
+    color: #00FF00;
+}
+
 a:visited {
-    color: #11C;
+    color: #008080;
 }
 
 #navi {

--- a/htdocs/wintern.css
+++ b/htdocs/wintern.css
@@ -53,8 +53,9 @@ a:visited {
 }
 
 ul.chat {
-    color: #FFF;
+    color: #000;
     list-style-type: none;
+    background-color: #FFF;
 }
 
 .chat time {

--- a/setup
+++ b/setup
@@ -39,6 +39,10 @@ fwrite(STDERR, "[DSN] {$sqlite_dsn}\n");
 
 $pdo = new \PDO($sqlite_dsn, null, null, [PDO::ATTR_PERSISTENT => true]);
 
+$pass_user0 = password_hash('system', PASSWORD_DEFAULT);
+$pass_user1 = password_hash('nimba', PASSWORD_DEFAULT);
+$pass_user2 = password_hash('cbcb', PASSWORD_DEFAULT);
+
 $queries = [
     'CREATE TABLE `users`( `id` INTEGER PRIMARY KEY AUTOINCREMENT, `slug` TEXT UNIQUE, `name` TEXT )',
     'CREATE TABLE `user_passwords`( `user_id` INTEGER PRIMARY KEY, `password` TEXT )',
@@ -57,12 +61,12 @@ $queries = [
     'CREATE INDEX `in_room_user_id` ON `in_rooms`( `user_id` )',
 
     'INSERT INTO `users` VALUES( 0, "system", "System" )',
-    'INSERT INTO `user_passwords` VALUES( 0, "system" )',
+    "INSERT INTO `user_passwords` VALUES( 0, \"{$pass_user0}\" )",
     'INSERT INTO `users` VALUES( 1, "root", "super user" )',
-    'INSERT INTO `user_passwords` VALUES( 1, "nimda" )',
+    "INSERT INTO `user_passwords` VALUES( 1, \"{$pass_user1}\" )",
     'INSERT INTO `user_profile` VALUES( 1, "http://pixiv.co.jp/", "pixiv", "AB" )',
     'INSERT INTO `users` VALUES( 2, "chobi", "チョビ" )',
-    'INSERT INTO `user_passwords` VALUES( 2, "cbcb" )',
+    "INSERT INTO `user_passwords` VALUES( 2, \"{$pass_user2}\" )",
     'INSERT INTO `user_profile` VALUES( 2, "http://times.pixiv.net/post/38140118669/%E3%83%94%E3%82%AF%E3%82%B7%E3%83%96%E3%81%AE%E7%A4%BE%E5%93%A1%E7%8A%AC", "chobi_pixiv", "Bombay" )',
     'INSERT INTO `rooms` VALUES( 1, "operators", "運営委員会" )',
     'INSERT INTO `rooms` VALUES( 2, "idobata-talks", "雑談の部屋" )',

--- a/src/Controller/login.php
+++ b/src/Controller/login.php
@@ -21,16 +21,18 @@ final class login
             $user = trim($_REQUEST['user']);
             $pass = $_REQUEST['password'];
             $query
-                = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name` '
+                = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name`, `user_passwords`.`password` '
                 . 'FROM `users` '
                 . 'INNER JOIN `user_passwords` '
                 . '   ON `users`.`id` = `user_passwords`.`user_id` '
-                . "WHERE `users`.`slug` = \"${user}\" "
-                . "  AND `user_passwords`.`password` = \"${pass}\" ";
+                . "WHERE `users`.`slug` = \"${user}\" ";
             $stmt = db()->prepare($query);
             $stmt->execute();
 
-            if ($login = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            $login = $stmt->fetch(\PDO::FETCH_ASSOC);
+            $passflag = password_verify($pass, $login['password']);
+
+            if ($login && $passflag) {
                 $app->session->set('user_id', $login['id']);
                 $app->session->set('user_slug', $login['slug']);
                 $app->session->set('user_name', $login['name']);

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -14,7 +14,8 @@ class regist
         $is_daburi = self::isTyouhuku(isset($_REQUEST['user']) ?? '');
 
         if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['password'])) {
-            $login = self::regist($_REQUEST['slug'], $_REQUEST['user'], $_REQUEST['password']);
+            $password_hash = password_hash($_REQUEST['password'], PASSWORD_DEFAULT);
+            $login = self::regist($_REQUEST['slug'], $_REQUEST['user'], $password_hash);
             $app->session->set('user_id', $login['id']);
             $app->session->set('user_slug', $login['slug']);
             $app->session->set('user_name', $login['name']);

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -32,9 +32,10 @@ final class room
         $stmt = db()->prepare($query);
         $stmt->execute();
         $talk = $stmt->fetchALL(\PDO::FETCH_ASSOC);
+        $rtalk = array_reverse($talk);
 
         $users = [];
-        foreach ($talk as $s) {
+        foreach ($rtalk as $s) {
             $user_id = $s['user_id'];
             if (empty($users[$user_id])) {
                 $query = "SELECT * FROM `users` WHERE `id` = {$user_id}";
@@ -47,7 +48,7 @@ final class room
         return new Response\TemplateResponse('room.tpl.html', [
             'slug' => $room,
             'room' => $data,
-            'talk' => $talk,
+            'talk' => $rtalk,
             'users' => $users,
         ]);
     }

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -16,7 +16,7 @@
             <fieldset>
                 <legend>Login</legend>
                 <input name=user value="{{ user }}" >
-                <input name=password>
+                <input name=password type="password">
                 <button type=submit>Login</button>
             </fieldset>
         </form>

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -12,7 +12,7 @@
             </fieldset>
         </form>
     {% else %}
-        <form action="/login" class="loginform">
+        <form action="/login" class="loginform" method="post">
             <fieldset>
                 <legend>Login</legend>
                 <input name=user value="{{ user }}" >

--- a/src/View/twig/layout.tpl.html
+++ b/src/View/twig/layout.tpl.html
@@ -15,6 +15,10 @@
                     <a href="/@{{ loginUser.slug }}">{{ loginUser.name }}</a>
                     <small><a href="/logout">ログアウト</a></small>
                 </div>
+                {% else %}
+                <div>
+                  <small><a href="/regist">ユーザー登録</a></small>
+                </div>
             {% endif %}
 
         </div>

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-    <form action="/login" class="loginform">
+    <form action="/login" class="loginform" method="post">
         <fieldset>
             <legend>Login</legend>
             <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -5,7 +5,7 @@
         <fieldset>
             <legend>Login</legend>
             <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
-            <input name=password placeholder="パスワード">
+            <input name=password placeholder="パスワード" type="password">
             <button type=submit>Login</button>
         </fieldset>
     </form>

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -6,7 +6,7 @@
             <legend>Regist</legend>
             <input name=user value="{{ user }}" required placeholder="ユーザー名" >
             <input name=slug value="{{ slug }}" required placeholder="ログイン名"  pattern="[a-zA-Z0-9]+">
-            <input name=password required placeholder="パスワード">
+            <input name=password required placeholder="パスワード" type="password">
             <button type=submit>Submit</button>
         </fieldset>
     </form>

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Regist{% endblock %}
 {% block content %}
-    <form action="/regist" class="loginform">
+    <form action="/regist" class="loginform" method="post">
         <fieldset>
             <legend>Regist</legend>
             <input name=user value="{{ user }}" required placeholder="ユーザー名" >


### PR DESCRIPTION
# 変更点
- パスワード入力フォームをパスワード形式に変更
- パスワードをhash化して保存するように変更
- ルームチャットの各列の背景を白に設定、メッセージ内容は黒に変更
- チャットを古い順に上から表示するように変更
- ログイン処理をpostで行うように変更
- ユーザー登録用リンクを追加
- リンクの色を変更
# 変更理由
### パスワード入力フォームをパスワード形式に変更

デフォルトのformだと入力内容がそのまま表示されてしまい、その場にいる他者に見られる可能性がある。
### パスワードをhash化して保存するように変更

平文で保存することは危険である。
### ルームチャットの各列の背景を白に設定、メッセージ内容は黒に変更

見づらかった。
### チャットを古い順に上から表示するように変更

チャットページは古いメッセージの方が上の方が見慣れている人が多いと判断した。
### ログイン処理をpostで行うように変更

getだとセッション内容がurlに表示される。
### ユーザー登録用リンクを追加

ページは用意されていたが、リンクが設置されていなかった。
### リンクの色を変更

見づらかった。
