### PR TITLE
pixiv-winter-internship 2015課題

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -15,12 +15,12 @@ call_user_func(function(){
 
     $routing_map = [
         'logout'   => ['GET',  '/logout',      'logout'],
-        'login'    => ['GET',  '/login',       'login'],
+        'login'    => ['POST', '/login',       'login'],
                       ['GET',  '/login',       'login'],
-        'regist'   => ['GET',  '/regist',      'regist'],
-                      ['POST', '/regist',      'regist'],
-        'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
-                      ['POST', '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
+        'regist'   => ['POST', '/regist',      'regist'],
+                      ['GET',  '/regist',      'regist'],
+        'room'     => ['POST', '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
+                      ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
         'add_romm' => ['POST', '/add_room',    'add_room'],
         'user'     => ['GET',  '/:user',       'user', ['user' => '/@[-a-zA-Z]+/']],
         'index'    => ['GET',  '/',            'top'],

--- a/setup
+++ b/setup
@@ -39,6 +39,11 @@ fwrite(STDERR, "[DSN] {$sqlite_dsn}\n");
 
 $pdo = new \PDO($sqlite_dsn, null, null, [PDO::ATTR_PERSISTENT => true]);
 
+$password_hash_options = [
+    'cost' => '11',
+    'salt' => mcrypt_create_iv(22, MCRYPT_DEV_URANDOM)
+];
+
 $queries = [
     'CREATE TABLE `users`( `id` INTEGER PRIMARY KEY AUTOINCREMENT, `slug` TEXT UNIQUE, `name` TEXT )',
     'CREATE TABLE `user_passwords`( `user_id` INTEGER PRIMARY KEY, `password` TEXT )',
@@ -57,12 +62,12 @@ $queries = [
     'CREATE INDEX `in_room_user_id` ON `in_rooms`( `user_id` )',
 
     'INSERT INTO `users` VALUES( 0, "system", "System" )',
-    'INSERT INTO `user_passwords` VALUES( 0, "system" )',
+    'INSERT INTO `user_passwords` VALUES( 0, "' . password_hash('system', PASSWORD_BCRYPT, $password_hash_options) . '" )',
     'INSERT INTO `users` VALUES( 1, "root", "super user" )',
-    'INSERT INTO `user_passwords` VALUES( 1, "nimda" )',
+    'INSERT INTO `user_passwords` VALUES( 1, "' . password_hash('nimda', PASSWORD_BCRYPT, $password_hash_options) .  '" )',
     'INSERT INTO `user_profile` VALUES( 1, "http://pixiv.co.jp/", "pixiv", "AB" )',
     'INSERT INTO `users` VALUES( 2, "chobi", "チョビ" )',
-    'INSERT INTO `user_passwords` VALUES( 2, "cbcb" )',
+    'INSERT INTO `user_passwords` VALUES( 2, "' . password_hash('cbcb', PASSWORD_BCRYPT, $password_hash_options) .  '" )',
     'INSERT INTO `user_profile` VALUES( 2, "http://times.pixiv.net/post/38140118669/%E3%83%94%E3%82%AF%E3%82%B7%E3%83%96%E3%81%AE%E7%A4%BE%E5%93%A1%E7%8A%AC", "chobi_pixiv", "Bombay" )',
     'INSERT INTO `rooms` VALUES( 1, "operators", "運営委員会" )',
     'INSERT INTO `rooms` VALUES( 2, "idobata-talks", "雑談の部屋" )',
@@ -74,11 +79,11 @@ foreach ($queries as $q) {
     fwrite(STDERR, "[SQL] {$q}\n");
     $stmt = $pdo->prepare($q);
     if ($stmt === false) {
-       fwrite(STDERR, sprintf("[Error] Query error \n"));
-       die;
+        fwrite(STDERR, sprintf("[Error] Query error \n"));
+        die;
     }
     if (!$stmt->execute()) {
-       fwrite(STDERR, sprintf("[Error] %s\n", print_r($stmt->errorInfo(), true)));
-       die;
+        fwrite(STDERR, sprintf("[Error] %s\n", print_r($stmt->errorInfo(), true)));
+        die;
     }
 }

--- a/src/Controller/add_room.php
+++ b/src/Controller/add_room.php
@@ -12,12 +12,14 @@ final class add_room
 {
     function action(\Baguette\Application $app, \Teto\Routing\Action $action)
     {
-        $is_daburi = self::isTyouhuku(isset($_REQUEST['slug']) ?? '');
+        if ( isset($app->post['slug']) ){
+            $is_daburi = self::isTyouhuku($app->post['slug']);
+        }
 
-        if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['name'])
-            && self::regist($_REQUEST['slug'], $_REQUEST['name'], $app->getLoginUser())
+        if (!$is_daburi && isset($app->post['slug'], $app->post['name'])
+            && self::regist($app->post['slug'], $app->post['name'], $app->getLoginUser())
         ) {
-            return new Response\RedirectResponse('/rooms/' . $_REQUEST['slug']);
+            return new Response\RedirectResponse('/rooms/' . $app->post['slug']);
         }
 
         return new Response\RedirectResponse('/');

--- a/src/Controller/login.php
+++ b/src/Controller/login.php
@@ -21,25 +21,27 @@ final class login
             $user = trim($_REQUEST['user']);
             $pass = $_REQUEST['password'];
             $query
-                = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name` '
+                = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name`, `user_passwords`.`password` '
                 . 'FROM `users` '
                 . 'INNER JOIN `user_passwords` '
                 . '   ON `users`.`id` = `user_passwords`.`user_id` '
-                . "WHERE `users`.`slug` = \"${user}\" "
-                . "  AND `user_passwords`.`password` = \"${pass}\" ";
+                . "WHERE `users`.`slug` = \"${user}\" ";
+            // . "  AND `user_passwords`.`password` = \"${pass}\" ";
             $stmt = db()->prepare($query);
             $stmt->execute();
 
             if ($login = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-                $app->session->set('user_id', $login['id']);
-                $app->session->set('user_slug', $login['slug']);
-                $app->session->set('user_name', $login['name']);
-                return new Response\RedirectResponse('/');
+                if (password_verify($pass, $login['password'])) {
+                    $app->session->set('user_id', $login['id']);
+                    $app->session->set('user_slug', $login['slug']);
+                    $app->session->set('user_name', $login['name']);
+                    return new Response\RedirectResponse('/');
+                }
             }
         }
 
         return new Response\TwigResponse('login.tpl.html', [
             'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
-        ]);
+            ]);
     }
 }

--- a/src/Controller/login.php
+++ b/src/Controller/login.php
@@ -17,9 +17,9 @@ final class login
         }
 
         // systemは特殊なユーザーなのでログインできない
-        if (isset($_REQUEST['user'], $_REQUEST['password']) && $_REQUEST['user'] != 'system') {
-            $user = trim($_REQUEST['user']);
-            $pass = $_REQUEST['password'];
+        if (isset($app->post['user'], $app->post['password']) && $app->post['user'] != 'system') {
+            $user = trim($app->post['user']);
+            $pass = $app->post['password'];
             $query
                 = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name`, `user_passwords`.`password` '
                 . 'FROM `users` '
@@ -41,7 +41,7 @@ final class login
         }
 
         return new Response\TwigResponse('login.tpl.html', [
-            'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
+            'user' => isset($app->post['user']) ? $app->post['user'] : null,
             ]);
     }
 }

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -12,12 +12,12 @@ class regist
         }
 
         // validate daburi
-        if ( isset($app->get['slug']) ){
-            $is_daburi = self::isTyouhuku($app->get['slug']);
+        if ( isset($app->post['slug']) ){
+            $is_daburi = self::isTyouhuku($app->post['slug']);
         } else { $is_daburi = 0; }
 
-        if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['password'])) {
-            $login = self::regist($_REQUEST['slug'], $_REQUEST['user'], $_REQUEST['password']);
+        if (!$is_daburi && isset($app->post['slug'], $app->post['password'])) {
+            $login = self::regist($app->post['slug'], $app->post['user'], $app->post['password']);
             $app->session->set('user_id', $login['id']);
             $app->session->set('user_slug', $login['slug']);
             $app->session->set('user_name', $login['name']);
@@ -26,7 +26,7 @@ class regist
         }
 
         return new Response\TwigResponse('regist.tpl.html', [
-            'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
+            'user' => isset($app->post['user']) ? $app->post['user'] : null,
             'is_daburi' => $is_daburi,
         ]);
     }
@@ -39,7 +39,6 @@ class regist
         }
 
         $user = trim($slug);
-        $pass = $_REQUEST['password'];
         $query = "SELECT * FROM `users` WHERE `slug` = \"${user}\" ";
         $stmt = db()->prepare($query);
         $stmt->execute();

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -19,7 +19,10 @@ final class room
         $stmt->execute();
         $data = $stmt->fetch(\PDO::FETCH_ASSOC);
 
-        if (!empty($_REQUEST['message'])) {
+        if (!empty($_REQUEST['message'])
+            && $_REQUEST['ticket'] == $app->session->get('ticket')
+            && $_SERVER['REQUEST_METHOD'] == 'POST' )
+        {
             $now = date('Y-m-d H:i:s', strtotime('+9 hours'));
             $message = str_replace('"', '\\"', $_REQUEST['message']);
             $user_id = $_REQUEST['user_id'];
@@ -27,6 +30,9 @@ final class room
             $stmt = db()->prepare($query);
             $stmt->execute();
         }
+
+        $ticket = uniqid();
+        $app->session->set('ticket', $ticket);
 
         $query = "SELECT * FROM `posts` WHERE `room_id` = {$data['id']} ORDER BY datetime(`posted_at`) DESC LIMIT 100";
         $stmt = db()->prepare($query);
@@ -49,6 +55,7 @@ final class room
             'room' => $data,
             'talk' => $talk,
             'users' => $users,
+            'ticket' => $ticket,
         ]);
     }
 }

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -12,14 +12,7 @@
             </fieldset>
         </form>
     {% else %}
-        <form action="/login" class="loginform">
-            <fieldset>
-                <legend>Login</legend>
-                <input name=user value="{{ user }}" >
-                <input name=password>
-                <button type=submit>Login</button>
-            </fieldset>
-        </form>
+        {% include 'shared/loginform.tpl.html' %}
     {% endif %}
     <h2>部屋一覧</h2>
     <ul>

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -1,12 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-    <form action="/login" class="loginform">
-        <fieldset>
-            <legend>Login</legend>
-            <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
-            <input name=password placeholder="パスワード">
-            <button type=submit>Login</button>
-        </fieldset>
-    </form>
+
+{% include 'shared/loginform.tpl.html' %}
+
 {% endblock %}

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Regist{% endblock %}
 {% block content %}
-    <form action="/regist" class="loginform">
+    <form action="/regist" method="post" class="loginform">
         <fieldset>
             <legend>Regist</legend>
             <input name=user value="{{ user }}" required placeholder="ユーザー名" >

--- a/src/View/twig/room.tpl.html
+++ b/src/View/twig/room.tpl.html
@@ -4,6 +4,7 @@
     {% if isLoggedIn %}
         <form action="/rooms/{{ slug }}" class=comment method=post>
             <input name=message>
+            <input name=ticket type=hidden value={{ ticket }}>
             <input name=user_id type=hidden value={{ loginUser.id }}>
             <input name=slug type=hidden value={{ slug }}>
             <button name=submit>更新</button>

--- a/src/View/twig/shared/loginform.tpl.html
+++ b/src/View/twig/shared/loginform.tpl.html
@@ -1,5 +1,5 @@
 
-<form action="/login" class="loginform">
+<form action="/login" method="post" class="loginform">
     <fieldset>
         <legend>Login</legend>
         <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">

--- a/src/View/twig/shared/loginform.tpl.html
+++ b/src/View/twig/shared/loginform.tpl.html
@@ -1,0 +1,9 @@
+
+<form action="/login" class="loginform">
+    <fieldset>
+        <legend>Login</legend>
+        <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">
+        <input name=password placeholder="パスワード" type='password'>
+        <button type=submit>Login</button>
+    </fieldset>
+</form>


### PR DESCRIPTION
# やったことﾘｽﾄ
## 1. ﾊﾟｽﾜｰﾄﾞの暗号化, 復号化

`password_hash`でﾊﾟｽﾜｰﾄﾞを暗号化してdbに格納. `password_verify`と使ってﾕｰｻﾞが入力したﾊﾟｽﾜｰﾄﾞを使ってﾛｸﾞｲﾝ.
### 懸念点

`password_hash`の挙動はﾊﾞｰｼﾞｮﾝ毎に異なる可能性がある?

> [PHP: password_hash - Manual](http://php.net/manual/ja/function.password-hash.php)

そのため, こっちでｵﾌﾟｼｮﾝを指定したほうがいいかもと思ったが, 非推奨だったので良く分からない.
## 2. ﾕｰｻﾞ登録やﾛｸﾞｲﾝをpostﾒｿｯﾄﾞで

getで行われたいた(危ない!!!)ので,postを使いました.
[BaguettePHP/Baguette](https://github.com/BaguettePHP/baguette)では`$app`で`$_REQUEST`とかにｱｸｾｽできるので, `$app->post`を使いました.
### 気になったこと

routingで同じﾓﾉが2つある!!!

```
'login'    => ['GET',  '/login',       'login'],
              ['GET',  '/login',       'login'],
```
## 3. isTyouhukuが動かない

`isset`の返り値はbooleanなのでどうやってもslugが重複しているかなんて分かりやしない.
というか, **引数がusername**. そのため, 
1. slug, messageが送られたかを確認
2. 送られてきた場合, 重複のﾁｪｯｸ
3. 送られてきてない場合, 素通り

あと, 以下のｺｰﾄﾞは動作に影響ないので消しまみた.

```
$pass = $_REQUEST['password'];
```
## 4. roomでmessage送信時におけるﾘﾛｰﾄﾞ&ﾌﾞﾗｳｻﾞﾊﾞｯｸ

roomでﾘﾛｰﾄﾞやﾌﾞﾗｳｻﾞﾊﾞｯｸをすると, 悲しいことに2度同じﾃﾞｰﾀが送られる(ﾕｰｻﾞが求める挙動ではない.
そのため, ﾁｹｯﾄを発行して対策をしました.
## 他にやったこと
### 1. loginformを共通化

loginformはtopとloginに表示されているが, 同じっぽいｺｰﾄﾞが2つ書かれている.
ﾒﾝﾃするときにﾊﾞｸﾞを生み出しやすく, 管理がしにくいのでtwigの`include`を使って共通化.
### 2. htmlのﾊﾟｽﾜｰﾄﾞﾌｫｰﾑを非表示に

loginformのほうは対応したがregistのほうは対応してない...
