### PR TITLE
pixiv winter internship 2015 課題 

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -16,7 +16,7 @@ call_user_func(function(){
     $routing_map = [
         'logout'   => ['GET',  '/logout',      'logout'],
         'login'    => ['GET',  '/login',       'login'],
-                      ['GET',  '/login',       'login'],
+                      ['POST', '/login',       'login'],
         'regist'   => ['GET',  '/regist',      'regist'],
                       ['POST', '/regist',      'regist'],
         'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -19,10 +19,10 @@ call_user_func(function(){
                       ['POST', '/login',       'login'],
         'regist'   => ['GET',  '/regist',      'regist'],
                       ['POST', '/regist',      'regist'],
-        'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
-                      ['POST', '/rooms/:slug', 'room', ['slug' => '/[-a-zA-Z]+/']],
+        'room'     => ['GET',  '/rooms/:slug', 'room', ['slug' => '/[a-zA-Z0-9]+/']],
+                      ['POST', '/rooms/:slug', 'room', ['slug' => '/[a-zA-Z0-9]+/']],
         'add_romm' => ['POST', '/add_room',    'add_room'],
-        'user'     => ['GET',  '/:user',       'user', ['user' => '/@[-a-zA-Z]+/']],
+        'user'     => ['GET',  '/:user',       'user', ['user' => '/@[a-zA-Z0-9]+/']],
         'index'    => ['GET',  '/',            'top'],
         '#404'     =>                          'fileloader',
     ];

--- a/src/Controller/add_room.php
+++ b/src/Controller/add_room.php
@@ -12,7 +12,7 @@ final class add_room
 {
     function action(\Baguette\Application $app, \Teto\Routing\Action $action)
     {
-        $name = filter_input(INPUT_POST, 'name');
+        $name = filter_input(INPUT_POST, 'name', FILTER_SANITIZE_SPECIAL_CHARS);
         $slug = filter_input(INPUT_POST, 'slug', FILTER_VALIDATE_REGEXP, ['options' =>
             ['regexp' => '/^[a-zA-Z0-9]+$/']
         ]);

--- a/src/Controller/add_room.php
+++ b/src/Controller/add_room.php
@@ -25,9 +25,9 @@ final class add_room
 
     private static function isTyouhuku(string $slug): bool
     {
-        $query = "SELECT * FROM `rooms` WHERE `slug` = \"${slug}\" ";
+        $query = 'SELECT * FROM `rooms` WHERE `slug` = :slug';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':slug' => $slug]);
         $data = $stmt->fetch(\PDO::FETCH_ASSOC);
 
         return !empty($data);
@@ -35,17 +35,17 @@ final class add_room
 
     private static function regist($slug, $name, $user): bool
     {
-        $query = "INSERT INTO `rooms`(`slug`, `name`) VALUES( \"{$slug}\", \"{$name}\" ); ";
+        $query = 'INSERT INTO `rooms`(`slug`, `name`) VALUES( :slug, :name )';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':slug' => $slug, ':name' => $name]);
         $id = db()->lastInsertId();
 
         $now = date('Y-m-d H:i:s', strtotime('+9 hours'));
         $user_name = $user->name;
-        $message = str_replace('"', '\\"', "**{$user_name}さん**が部屋を作りました！");
-        $query = "INSERT INTO `posts` VALUES( {$id}, 0, \"{$now}\", \"{$message}\" )";
+        $message = "**{$user_name}さん**が部屋を作りました！";
+        $query = 'INSERT INTO `posts` VALUES( :id, 0, :now, :message )';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':id' => $id, ':now' => $now, ':message' => $message]);
 
         return true;
     }

--- a/src/Controller/add_room.php
+++ b/src/Controller/add_room.php
@@ -12,12 +12,15 @@ final class add_room
 {
     function action(\Baguette\Application $app, \Teto\Routing\Action $action)
     {
-        $is_daburi = self::isTyouhuku(isset($_REQUEST['slug']) ?? '');
+        $name = filter_input(INPUT_POST, 'name');
+        $slug = filter_input(INPUT_POST, 'slug', FILTER_VALIDATE_REGEXP, ['options' =>
+            ['regexp' => '/^[a-zA-Z0-9]+$/']
+        ]);
 
-        if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['name'])
-            && self::regist($_REQUEST['slug'], $_REQUEST['name'], $app->getLoginUser())
+        if (!empty($name) && !empty($slug) && !self::isTyouhuku($slug)
+         && self::regist($slug, $name, $app->getLoginUser())
         ) {
-            return new Response\RedirectResponse('/rooms/' . $_REQUEST['slug']);
+            return new Response\RedirectResponse('/rooms/' . $slug);
         }
 
         return new Response\RedirectResponse('/');

--- a/src/Controller/login.php
+++ b/src/Controller/login.php
@@ -16,10 +16,13 @@ final class login
             return new Response\RedirectResponse('/');
         }
 
+        $user = filter_input(INPUT_POST, 'user', FILTER_VALIDATE_REGEXP, ['options' =>
+            ['regexp' => '/^[a-zA-Z0-9]+$/']
+        ]);
+        $pass = filter_input(INPUT_POST, 'password');
+
         // systemは特殊なユーザーなのでログインできない
-        if (isset($_REQUEST['user'], $_REQUEST['password']) && $_REQUEST['user'] != 'system') {
-            $user = trim($_REQUEST['user']);
-            $pass = $_REQUEST['password'];
+        if (!empty($user) && !empty($pass) && $user !== 'system') {
             $query
                 = 'SELECT `users`.`id`, `users`.`slug`, `users`.`name` '
                 . 'FROM `users` '
@@ -39,7 +42,7 @@ final class login
         }
 
         return new Response\TwigResponse('login.tpl.html', [
-            'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
+            'user' => $user ?? null,
         ]);
     }
 }

--- a/src/Controller/login.php
+++ b/src/Controller/login.php
@@ -25,10 +25,10 @@ final class login
                 . 'FROM `users` '
                 . 'INNER JOIN `user_passwords` '
                 . '   ON `users`.`id` = `user_passwords`.`user_id` '
-                . "WHERE `users`.`slug` = \"${user}\" "
-                . "  AND `user_passwords`.`password` = \"${pass}\" ";
+                . 'WHERE `users`.`slug` = :user '
+                . '  AND `user_passwords`.`password` = :pass';
             $stmt = db()->prepare($query);
-            $stmt->execute();
+            $stmt->execute([':user' => $user, ':pass' => $pass]);
 
             if ($login = $stmt->fetch(\PDO::FETCH_ASSOC)) {
                 $app->session->set('user_id', $login['id']);

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -11,10 +11,14 @@ class regist
             return new Response\RedirectResponse('/');
         }
 
-        $is_daburi = self::isTyouhuku(isset($_REQUEST['user']) ?? '');
+        $user = filter_input(INPUT_POST, 'user', FILTER_SANITIZE_SPECIAL_CHARS);
+        $slug = filter_input(INPUT_POST, 'slug', FILTER_VALIDATE_REGEXP, ['options' =>
+            ['regexp' => '/^[a-zA-Z0-9]+$/']
+        ]);
+        $password = filter_input(INPUT_POST, 'password');
 
-        if (!$is_daburi && isset($_REQUEST['slug'], $_REQUEST['password'])) {
-            $login = self::regist($_REQUEST['slug'], $_REQUEST['user'], $_REQUEST['password']);
+        if (!empty($user) && !empty($slug) && !empty($password) && !self::isTyouhuku($user)) {
+            $login = self::regist($slug, $user, $password);
             $app->session->set('user_id', $login['id']);
             $app->session->set('user_slug', $login['slug']);
             $app->session->set('user_name', $login['name']);
@@ -23,8 +27,7 @@ class regist
         }
 
         return new Response\TwigResponse('regist.tpl.html', [
-            'user' => isset($_REQUEST['user']) ? $_REQUEST['user'] : null,
-            'is_daburi' => $is_daburi,
+            'user' => $user ?? null,
         ]);
     }
 

--- a/src/Controller/regist.php
+++ b/src/Controller/regist.php
@@ -37,9 +37,9 @@ class regist
 
         $user = trim($user_name);
         $pass = $_REQUEST['password'];
-        $query = "SELECT * FROM `users` WHERE `slug` = \"${user}\" ";
+        $query = 'SELECT * FROM `users` WHERE `slug` = :user';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':user' => $user]);
         $data = $stmt->fetch(\PDO::FETCH_ASSOC);
 
         return !empty($data);
@@ -47,14 +47,14 @@ class regist
 
     private static function regist($slug, $name, $password): array
     {
-        $query = "INSERT INTO `users`(`slug`, `name`) VALUES( \"{$slug}\", \"{$name}\" ); ";
+        $query = 'INSERT INTO `users`(`slug`, `name`) VALUES( :slug, :name )';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':slug' => $slug, ':name' => $name]);
 
         $id = db()->lastInsertId();
-        $query = "INSERT INTO `user_passwords` VALUES( {$id}, \"{$password}\" ); ";
+        $query = 'INSERT INTO `user_passwords` VALUES( :id, :password )';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':id' => $id, ':password' => $password]);
 
         return [
             'id' => $id,

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -25,7 +25,7 @@ final class room
             $stmt = db()->prepare($query);
             $stmt->execute([
                 ':data_id' => $data['id'],
-                ':user_id' => filter_input(INPUT_POST, 'user_id'),
+                ':user_id' => $app->getLoginUser()->id,
                 ':now' => $now,
                 ':message' => filter_input(INPUT_POST, 'message', FILTER_SANITIZE_SPECIAL_CHARS),
             ]);

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -27,7 +27,7 @@ final class room
                 ':data_id' => $data['id'],
                 ':user_id' => filter_input(INPUT_POST, 'user_id'),
                 ':now' => $now,
-                ':message' => filter_input(INPUT_POST, 'message'),
+                ':message' => filter_input(INPUT_POST, 'message', FILTER_SANITIZE_SPECIAL_CHARS),
             ]);
         }
 

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -19,18 +19,15 @@ final class room
         $stmt->execute([':room' => $room]);
         $data = $stmt->fetch(\PDO::FETCH_ASSOC);
 
-        if (!empty($_REQUEST['message'])) {
+        if (!empty(filter_input(INPUT_POST, 'message'))) {
             $now = date('Y-m-d H:i:s', strtotime('+9 hours'));
-            //$message = str_replace('"', '\\"', $_REQUEST['message']);
-            $message = $_REQUEST['message'];
-            $user_id = $_REQUEST['user_id'];
             $query = 'INSERT INTO `posts` VALUES( :data_id, :user_id, :now, :message )';
             $stmt = db()->prepare($query);
             $stmt->execute([
                 ':data_id' => $data['id'],
-                ':user_id' => $user_id,
+                ':user_id' => filter_input(INPUT_POST, 'user_id'),
                 ':now' => $now,
-                ':message' => $message,
+                ':message' => filter_input(INPUT_POST, 'message'),
             ]);
         }
 

--- a/src/Controller/room.php
+++ b/src/Controller/room.php
@@ -14,32 +14,38 @@ final class room
     {
         $room  = $action->param['slug'];
 
-        $query = "SELECT * FROM `rooms` WHERE `slug` = \"{$room}\"";
+        $query = 'SELECT * FROM `rooms` WHERE `slug` = :room';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':room' => $room]);
         $data = $stmt->fetch(\PDO::FETCH_ASSOC);
 
         if (!empty($_REQUEST['message'])) {
             $now = date('Y-m-d H:i:s', strtotime('+9 hours'));
-            $message = str_replace('"', '\\"', $_REQUEST['message']);
+            //$message = str_replace('"', '\\"', $_REQUEST['message']);
+            $message = $_REQUEST['message'];
             $user_id = $_REQUEST['user_id'];
-            $query = "INSERT INTO `posts` VALUES( {$data['id']}, {$user_id}, \"{$now}\", \"{$message}\" )";
+            $query = 'INSERT INTO `posts` VALUES( :data_id, :user_id, :now, :message )';
             $stmt = db()->prepare($query);
-            $stmt->execute();
+            $stmt->execute([
+                ':data_id' => $data['id'],
+                ':user_id' => $user_id,
+                ':now' => $now,
+                ':message' => $message,
+            ]);
         }
 
-        $query = "SELECT * FROM `posts` WHERE `room_id` = {$data['id']} ORDER BY datetime(`posted_at`) DESC LIMIT 100";
+        $query = 'SELECT * FROM `posts` WHERE `room_id` = :data_id ORDER BY datetime(`posted_at`) DESC LIMIT 100';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':data_id' => $data['id']]);
         $talk = $stmt->fetchALL(\PDO::FETCH_ASSOC);
 
         $users = [];
         foreach ($talk as $s) {
             $user_id = $s['user_id'];
             if (empty($users[$user_id])) {
-                $query = "SELECT * FROM `users` WHERE `id` = {$user_id}";
+                $query = 'SELECT * FROM `users` WHERE `id` = :user_id';
                 $stmt = db()->prepare($query);
-                $stmt->execute();
+                $stmt->execute([':user_id' => $user_id]);
                 $users[$user_id] = $stmt->fetch(\PDO::FETCH_ASSOC);
             }
         }

--- a/src/Controller/user.php
+++ b/src/Controller/user.php
@@ -13,9 +13,9 @@ final class user
     public function action(\Baguette\Application $app, \Teto\Routing\Action $action)
     {
         $name = ltrim($action->param['user'], '@');
-        $query = "SELECT * FROM `users` WHERE `slug` = \"{$name}\"";
+        $query = 'SELECT * FROM `users` WHERE `slug` = :name';
         $stmt = db()->prepare($query);
-        $stmt->execute();
+        $stmt->execute([':name' => $name]);
         $user = $stmt->fetch(\PDO::FETCH_ASSOC);
 
         return new Response\TemplateResponse('user.tpl.html', [

--- a/src/View/twig/index.tpl.html
+++ b/src/View/twig/index.tpl.html
@@ -12,7 +12,7 @@
             </fieldset>
         </form>
     {% else %}
-        <form action="/login" class="loginform">
+        <form action="/login" method="post" class="loginform">
             <fieldset>
                 <legend>Login</legend>
                 <input name=user value="{{ user }}" >

--- a/src/View/twig/login.tpl.html
+++ b/src/View/twig/login.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-    <form action="/login" class="loginform">
+    <form action="/login" method="post" class="loginform">
         <fieldset>
             <legend>Login</legend>
             <input name=user value="{{ user }}" placeholder="ユーザー名" pattern="[a-zA-Z0-9]+">

--- a/src/View/twig/regist.tpl.html
+++ b/src/View/twig/regist.tpl.html
@@ -1,7 +1,7 @@
 {% extends "layout.tpl.html" %}
 {% block title %}Regist{% endblock %}
 {% block content %}
-    <form action="/regist" class="loginform">
+    <form action="/regist" method="post" class="loginform">
         <fieldset>
             <legend>Regist</legend>
             <input name=user value="{{ user }}" required placeholder="ユーザー名" >

--- a/src/View/twig/room.tpl.html
+++ b/src/View/twig/room.tpl.html
@@ -4,7 +4,6 @@
     {% if isLoggedIn %}
         <form action="/rooms/{{ slug }}" class=comment method=post>
             <input name=message>
-            <input name=user_id type=hidden value={{ loginUser.id }}>
             <input name=slug type=hidden value={{ slug }}>
             <button name=submit>更新</button>
         </form>


### PR DESCRIPTION
#### 修正項目
##### ログイン、ユーザ作成、部屋の作成のリクエストをpostメソッドに変更した
- 入力項目がurlに表示され履歴に残ることを防ぐため
##### sql への変数の展開を文字列内で変数を展開する方法からプリペアドステートメントを使う方法に変更した
- sqlインジェクションを回避するため
##### ユーザの入力項目の特殊文字をエスケープするようにした
- タグ埋め込みによるxssを防ぐため
##### ユーザが入力した、ユーザ名、部屋のslugにサーバーサイドでもバリデーションをかけるようにした
- ルールは、クライアントサイドで指定されているものと同じ、１文字以上の英数字のみを許可するようにした
- クライアントサイドのバリデーションは回避することができ、不十分であるため
##### ルーティングのパラメータのバリデーションのルールを１文字以上の英数字を許可することにした
- 上で変更したユーザ名及び部屋のslugのルールに合わせるため
